### PR TITLE
Add debug lines & fix changelog extraction logic in workflow

### DIFF
--- a/.github/workflows/release-the-blueprint.yaml
+++ b/.github/workflows/release-the-blueprint.yaml
@@ -11,14 +11,14 @@ permissions:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    env:
+      CHANGELOG: ""
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Determine variables
         id: determine-variables
         run: |
-          echo "github_ref=$GITHUB_REF"
-          echo "------"
           folder=${GITHUB_REF#*/tags/}
           folder=${folder%-*}
           version=${GITHUB_REF##*/}
@@ -30,14 +30,24 @@ jobs:
           echo "folder=$folder" >>$GITHUB_OUTPUT
           echo "version=$version" >>$GITHUB_OUTPUT
           echo "release_name=$release_name" >>$GITHUB_OUTPUT
-          echo GITHUB_OUTPUT=$GITHUB_OUTPUT
 
       - name: Build
         run: python3 tools/fatul.py encode -v ${{ steps.determine-variables.outputs.folder }}/book ${{ steps.determine-variables.outputs.folder }}-${{ steps.determine-variables.outputs.version }}.txt
       - name: Extract Changelog
         run: |
-          changelog=$(python3 tools/extract-changelog.py ${{ steps.determine-variables.outputs.folder }} ${{ steps.determine-variables.outputs.version }})
-          echo "changelog=$changelog" >>$GITHUB_OUTPUT
+          CHANGELOG=$(python3 tools/extract-changelog.py ${{ steps.determine-variables.outputs.folder }} ${{ steps.determine-variables.outputs.version }})
+          echo "CHANGELOG<<EOF" >>$GITHUB_ENV
+          echo "$CHANGELOG" >>$GITHUB_ENV
+          echo "EOF" >>$GITHUB_ENV
+      - name: Debug Variables
+        run: |
+          echo github_ref=$GITHUB_REF
+          echo "------"
+          echo GITHUB_OUTPUT=$GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
+          echo "------"
+          echo GITHUB_ENV=$GITHUB_ENV
+          cat $GITHUB_ENV
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
@@ -46,6 +56,6 @@ jobs:
           body: |
             Read about the blueprint & instructions [here](https://github.com/bcwhite-code/brians-blueprints/blob/main/${{ steps.determine-variables.outputs.folder }})
             Changelog:
-            ${{ steps.determine-variables.outputs.changelog }}
+            ${{ env.CHANGELOG }}
             Full Changelog [here](https://github.com/bcwhite-code/brians-blueprints/blob/main/${{ steps.determine-variables.outputs.folder }}/CHANGELOG.md)
           name: ${{ steps.determine-variables.outputs.release_name}}

--- a/.github/workflows/release-the-blueprint.yaml
+++ b/.github/workflows/release-the-blueprint.yaml
@@ -58,7 +58,7 @@ jobs:
           fail_on_unmatched_files: true
           body: |
             Read about the blueprint & instructions [here](https://github.com/bcwhite-code/brians-blueprints/blob/main/${{ steps.determine-variables.outputs.folder }})
+            Full Changelog [here](https://github.com/bcwhite-code/brians-blueprints/blob/main/${{ steps.determine-variables.outputs.folder }}/CHANGELOG.md)
             Changelog:
             ${{ env.CHANGELOG }}
-            Full Changelog [here](https://github.com/bcwhite-code/brians-blueprints/blob/main/${{ steps.determine-variables.outputs.folder }}/CHANGELOG.md)
           name: ${{ steps.determine-variables.outputs.release_name}}

--- a/.github/workflows/release-the-blueprint.yaml
+++ b/.github/workflows/release-the-blueprint.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: Determine variables
         id: determine-variables
         run: |
+          echo "github_ref=$GITHUB_REF"
+          echo "------"
           folder=${GITHUB_REF#*/tags/}
           folder=${folder%-*}
           version=${GITHUB_REF##*/}
@@ -28,6 +30,7 @@ jobs:
           echo "folder=$folder" >>$GITHUB_OUTPUT
           echo "version=$version" >>$GITHUB_OUTPUT
           echo "release_name=$release_name" >>$GITHUB_OUTPUT
+          echo GITHUB_OUTPUT=$GITHUB_OUTPUT
 
       - name: Build
         run: python3 tools/fatul.py encode -v ${{ steps.determine-variables.outputs.folder }}/book ${{ steps.determine-variables.outputs.folder }}-${{ steps.determine-variables.outputs.version }}.txt

--- a/.github/workflows/release-the-blueprint.yaml
+++ b/.github/workflows/release-the-blueprint.yaml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Determine variables
         id: determine-variables
         run: |
@@ -31,23 +32,25 @@ jobs:
           echo "version=$version" >>$GITHUB_OUTPUT
           echo "release_name=$release_name" >>$GITHUB_OUTPUT
 
+          echo github_ref=$GITHUB_REF
+          echo "------"
+          echo GITHUB_OUTPUT=$GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
+
       - name: Build
         run: python3 tools/fatul.py encode -v ${{ steps.determine-variables.outputs.folder }}/book ${{ steps.determine-variables.outputs.folder }}-${{ steps.determine-variables.outputs.version }}.txt
+
       - name: Extract Changelog
         run: |
           CHANGELOG=$(python3 tools/extract-changelog.py ${{ steps.determine-variables.outputs.folder }} ${{ steps.determine-variables.outputs.version }})
           echo "CHANGELOG<<EOF" >>$GITHUB_ENV
           echo "$CHANGELOG" >>$GITHUB_ENV
           echo "EOF" >>$GITHUB_ENV
-      - name: Debug Variables
-        run: |
-          echo github_ref=$GITHUB_REF
-          echo "------"
-          echo GITHUB_OUTPUT=$GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+
           echo "------"
           echo GITHUB_ENV=$GITHUB_ENV
           cat $GITHUB_ENV
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/tileable-reactor/CHANGELOG.md
+++ b/tileable-reactor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Don't update to a new version that is different in the first or second digit while in the process of building the reactor, including extending an existing one with more rows. Though very similar, they are **not** compatible!
 
+## v5.0.0
+
+- Updated for Factorio 2.x.
+
 ## v4.3.2
 
 - Fixed lamps in "+5 rows" blueprint.

--- a/tools/github-workflow-test.sh
+++ b/tools/github-workflow-test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+GITHUB_REF="self-building-factory-5.0.0"
+
+echo github_ref=$GITHUB_REF
+folder=${GITHUB_REF#*/tags/}
+folder=${folder%-*}
+version=${GITHUB_REF##*/}
+version=${version//[!0-9.]/}
+
+release_name=$(echo "${folder//-/ }" | sed -e "s/\b\(.\)/\u\1/g;s/Brians/Brian's/g")
+release_name="$release_name $version"
+
+echo "folder=$folder"
+echo "version=$version"
+echo "release_name=$release_name"


### PR DESCRIPTION
While trying to debug the workflow file, I found that it does work as intended.

But there was a flaw in changelog step. Turns out that multiline strings do not get assigned properly. 
So I have used a different approach (from [here](https://trstringer.com/github-actions-multiline-strings/)).

Still I have added some debug lines which will help me further investigate this and determine if it is workflow's code problem or GitHub problem.

If it is GitHub problem, then I may need to update the runner/container (i.e. add a step of `sudo apt update && sudo apt upgrade`).

If it is workflow code problem, this PR adds some debug lines to help figure out the problem.