### PR TITLE
Add requester chest for artillery shells

### DIFF
--- a/self-building-factory/book/red-mall.json
+++ b/self-building-factory/book/red-mall.json
@@ -22520,6 +22520,7 @@
         "position": {"x": 338.5, "y": 74.5}
       },
       {"name": "fast-inserter", "direction": 12, "position": {"x": 344.5, "y": 74.5}},
+      {"name": "fast-inserter", "direction": 12, "position": {"x": 344.5, "y": 75.5}},
       {
         "name": "fast-inserter",
         "direction": 12,
@@ -36312,6 +36313,21 @@
             {
               "index": 1,
               "filters": [{"name": "logistic-robot", "comparator": "=", "count": 10, "index": 1, "quality": "normal"}]
+            }
+          ]
+        }
+      },
+      {
+        "name": "requester-chest",
+        "position": {"x": 343.5, "y": 75.5},
+        "request_filters": {
+          "sections": [
+            {
+              "index": 1,
+              "filters": [
+                {"name": "calcite", "comparator": "=", "count": 2, "index": 2, "quality": "normal"},
+                {"name": "tungsten-plate", "comparator": "=", "count": 10, "index": 3, "quality": "normal"}
+              ]
             }
           ]
         }


### PR DESCRIPTION
In Factorio 2.0 you need to have Calcite and Tungsten Plates for artillery shells. I put it in between the existing red underground belts.
![image](https://github.com/user-attachments/assets/8abf6980-fa3b-450f-bb3a-bc568c533837)
