### PR TITLE
snap the space rocket to the same grid as the mall to make it obvious where to put it

### DIFF
--- a/self-building-factory/book/space/mall-rocket.json
+++ b/self-building-factory/book/space/mall-rocket.json
@@ -4,9 +4,10 @@
     "item": "blueprint",
     "label": "Mall Rocket",
     "description": "Add this to the Red Mall to launch a few rockets and start basic Space Science.",
-    "shift_x": 623,
-    "shift_y": -1294,
-    "version": 562949954797573,
+    "absolute-snapping": true,
+    "shift_x": 120,
+    "shift_y": 48,
+    "version": 562949955256321,
     "entities": [
       {
         "name": "assembling-machine-2",
@@ -648,6 +649,8 @@
       {"index": 1, "signal": {"name": "signal-M", "type": "virtual"}},
       {"index": 2, "signal": {"name": "fast-transport-belt"}}
     ],
+    "position-relative-to-grid": {"x": -25, "y": 54},
+    "snap-to-grid": {"x": 110, "y": 110},
     "wires": [
       ["2,5", 1, "2,6", 1],
       ["7,5", 5, "2,8", 5],


### PR DESCRIPTION
My goal was to encode this:
![image](https://github.com/user-attachments/assets/938dd9cc-6a79-4d51-bdd0-304c2a672711)
![image](https://github.com/user-attachments/assets/a56a2c20-7dfd-4259-8a8c-2ef942f03bcc)


The `fatul` tool seems to be non-deterministic, so I tried to get the parts out of `git add -p` that seemed to be relevant but I might need more or less of it.